### PR TITLE
Drop Newtonsoft Unity assembly references

### DIFF
--- a/Datra.SampleData/Datra.SampleData.asmdef
+++ b/Datra.SampleData/Datra.SampleData.asmdef
@@ -9,7 +9,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "Newtonsoft.Json.dll",
         "YamlDotNet.dll"
     ],
     "autoReferenced": true,

--- a/Datra/Converters/PolymorphicYamlSupport.cs
+++ b/Datra/Converters/PolymorphicYamlSupport.cs
@@ -10,7 +10,7 @@ using YamlDotNet.Serialization;
 namespace Datra.Converters
 {
     /// <summary>
-    /// Resolves type names to Type objects, similar to PortableTypeBinder for JSON.
+    /// Resolves type names to Type objects for legacy YAML polymorphism.
     /// Enables YAML portability across different assembly configurations.
     /// </summary>
     public class PortableTypeResolver

--- a/Datra/Datra.asmdef
+++ b/Datra/Datra.asmdef
@@ -7,7 +7,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "Newtonsoft.Json.dll",
         "YamlDotNet.dll"
     ],
     "autoReferenced": true,

--- a/Datra/Repositories/DeepCloner.cs
+++ b/Datra/Repositories/DeepCloner.cs
@@ -20,7 +20,7 @@ namespace Datra.Repositories
             var opts = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-                // Match Newtonsoft round-trip semantics: Datra data classes occasionally expose
+                // Match Datra's legacy round-trip semantics: Datra data classes occasionally expose
                 // public fields (e.g. PooledPrefab.Path). STJ excludes fields by default — turning
                 // it on keeps DeepCloner.Clone behaviourally compatible.
                 IncludeFields = true,

--- a/Datra/Serializers/DatraJsonHelpers.cs
+++ b/Datra/Serializers/DatraJsonHelpers.cs
@@ -8,7 +8,7 @@ using Datra.Localization;
 namespace Datra.Serializers
 {
     /// <summary>
-    /// STJ option helpers that re-create Datra's Newtonsoft-era contract semantics.
+    /// STJ option helpers that re-create Datra's legacy JSON contract semantics.
     /// </summary>
     internal static class DatraJsonHelpers
     {


### PR DESCRIPTION
## Summary
- remove obsolete Newtonsoft.Json precompiled references from Unity asmdefs
- update remaining legacy JSON comments now that Datra runtime JSON is STJ-based

## Validation
- dotnet build Datra/Datra.csproj
- dotnet list Datra/Datra.csproj package --include-transitive | rg Newtonsoft (no output)

Part of penspanic/tidemark#177