### PR TITLE
Allow consumers to skip generated YAML serializers

### DIFF
--- a/Datra.Generators/DataContextSourceGenerator.cs
+++ b/Datra.Generators/DataContextSourceGenerator.cs
@@ -127,6 +127,10 @@ namespace Datra.Generators
             bool enableDebugLogging = false;
             bool emitPhysicalFiles = false;
             string physicalFilesPath = null;
+            bool emitYamlSerializers = GetBoolBuildProperty(
+                context,
+                "DatraEmitYamlSerializers",
+                defaultValue: true);
 
             // Read optional named arguments
             foreach (var arg in configAttr.NamedArguments)
@@ -177,7 +181,7 @@ namespace Datra.Generators
                 GeneratorLogger.AddDebugOutput(context);
                 return;
             }
-            GeneratorLogger.Log($"Found DatraConfigurationAttribute: ContextName={contextName}, Namespace={generatedNamespace}, EnableLocalization={enableLocalization}, LocalizationKeyDataPath={localizationKeysPath}, LocalizationDataPath={localizationDataPath}, DefaultLanguage={defaultLanguage}, EnableDebugLogging={enableDebugLogging}, EmitPhysicalFiles={emitPhysicalFiles}, PhysicalFilesPath={physicalFilesPath}");
+            GeneratorLogger.Log($"Found DatraConfigurationAttribute: ContextName={contextName}, Namespace={generatedNamespace}, EnableLocalization={enableLocalization}, LocalizationKeyDataPath={localizationKeysPath}, LocalizationDataPath={localizationDataPath}, DefaultLanguage={defaultLanguage}, EnableDebugLogging={enableDebugLogging}, EmitPhysicalFiles={emitPhysicalFiles}, PhysicalFilesPath={physicalFilesPath}, EmitYamlSerializers={emitYamlSerializers}");
 
             // Filter out localization models
             var filteredModels = dataModels
@@ -203,7 +207,7 @@ namespace Datra.Generators
             GeneratorLogger.Log($"Generated {contextName}.g.cs");
 
             // Generate DataModel files
-            var dataModelGenerator = new DataModelGenerator(context);
+            var dataModelGenerator = new DataModelGenerator(emitYamlSerializers);
             foreach (var model in dataModels)
             {
                 var dataModelCode = dataModelGenerator.GenerateDataModelFile(model);
@@ -247,6 +251,30 @@ namespace Datra.Generators
             {
                 GeneratorLogger.AddDebugOutput(context);
             }
+        }
+
+        /// <summary>
+        /// Read a bool MSBuild property exposed to analyzers as
+        /// build_property.PropertyName.
+        /// </summary>
+        private static bool GetBoolBuildProperty(
+            GeneratorExecutionContext context,
+            string propertyName,
+            bool defaultValue)
+        {
+            if (!context.AnalyzerConfigOptions.GlobalOptions.TryGetValue(
+                    $"build_property.{propertyName}",
+                    out var value))
+            {
+                return defaultValue;
+            }
+
+            if (bool.TryParse(value, out var parsed))
+            {
+                return parsed;
+            }
+
+            return defaultValue;
         }
 
         /// <summary>

--- a/Datra.Generators/Generators/DataModelGenerator.cs
+++ b/Datra.Generators/Generators/DataModelGenerator.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Datra.Generators.Builders;
 using Datra.Generators.Models;
 
@@ -10,11 +8,11 @@ namespace Datra.Generators.Generators
 {
     internal class DataModelGenerator
     {
-        private readonly GeneratorExecutionContext _context;
+        private readonly bool _emitYamlSerializers;
         
-        public DataModelGenerator(GeneratorExecutionContext context)
+        public DataModelGenerator(bool emitYamlSerializers = true)
         {
-            _context = context;
+            _emitYamlSerializers = emitYamlSerializers;
         }
         
         private static bool IsPrimitiveType(string typeName)
@@ -253,7 +251,7 @@ namespace Datra.Generators.Generators
 
             // Generate YAML-specific methods without serializer parameter
             var isYamlFormat = CodeBuilder.IsYamlFormat(model.Format, model.FilePath);
-            if (isYamlFormat)
+            if (isYamlFormat && _emitYamlSerializers)
             {
                 codeBuilder.AddBlankLine();
 
@@ -298,7 +296,7 @@ namespace Datra.Generators.Generators
                     var jsonBuilder = new JsonSerializerBuilder();
                     jsonBuilder.GenerateSingleDeserializer(codeBuilder, model, simpleTypeName);
                     break;
-                case "Yaml":
+                case "Yaml" when _emitYamlSerializers:
                     var yamlBuilder = new YamlSerializerBuilder();
                     yamlBuilder.GenerateSingleDeserializer(codeBuilder, model, simpleTypeName);
                     break;
@@ -319,7 +317,7 @@ namespace Datra.Generators.Generators
                     var jsonBuilder2 = new JsonSerializerBuilder();
                     jsonBuilder2.GenerateSingleSerializer(codeBuilder, model, simpleTypeName);
                     break;
-                case "Yaml":
+                case "Yaml" when _emitYamlSerializers:
                     var yamlBuilder2 = new YamlSerializerBuilder();
                     yamlBuilder2.GenerateSingleSerializer(codeBuilder, model, simpleTypeName);
                     break;
@@ -332,7 +330,7 @@ namespace Datra.Generators.Generators
 
             // Generate YAML-specific methods without serializer parameter
             var isYamlFormat = CodeBuilder.IsYamlFormat(model.Format, model.FilePath);
-            if (isYamlFormat)
+            if (isYamlFormat && _emitYamlSerializers)
             {
                 codeBuilder.AddBlankLine();
 

--- a/Datra.Tests/DataModelGeneratorTests.cs
+++ b/Datra.Tests/DataModelGeneratorTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using Datra.Generators.Generators;
+using Datra.Generators.Models;
+using Xunit;
+
+namespace Datra.Tests
+{
+    public class DataModelGeneratorTests
+    {
+        [Fact]
+        public void GenerateDataModelFile_YamlTable_EmitsYamlHelpersByDefault()
+        {
+            var generator = new DataModelGenerator();
+
+            var code = generator.GenerateDataModelFile(CreateYamlTableModel());
+
+            Assert.Contains("DeserializeYaml", code);
+            Assert.Contains("SerializeYaml", code);
+            Assert.Contains("YamlDotNet", code);
+        }
+
+        [Fact]
+        public void GenerateDataModelFile_YamlTable_CanSkipYamlHelpers()
+        {
+            var generator = new DataModelGenerator(emitYamlSerializers: false);
+
+            var code = generator.GenerateDataModelFile(CreateYamlTableModel());
+
+            Assert.Contains("serializer.DeserializeTable<int, MonsterData>(data);", code);
+            Assert.Contains("serializer.SerializeTable<int, MonsterData>(table);", code);
+            Assert.DoesNotContain("DeserializeYaml", code);
+            Assert.DoesNotContain("SerializeYaml", code);
+            Assert.DoesNotContain("YamlDotNet", code);
+        }
+
+        [Fact]
+        public void GenerateDataModelFile_YamlSingle_CanSkipDirectYamlDeserializer()
+        {
+            var generator = new DataModelGenerator(emitYamlSerializers: false);
+
+            var code = generator.GenerateDataModelFile(CreateYamlSingleModel());
+
+            Assert.Contains("serializer.DeserializeSingle<GameSettings>(data);", code);
+            Assert.Contains("serializer.SerializeSingle<GameSettings>(data);", code);
+            Assert.DoesNotContain("DeserializeYaml", code);
+            Assert.DoesNotContain("SerializeYaml", code);
+            Assert.DoesNotContain("YamlDotNet", code);
+        }
+
+        private static DataModelInfo CreateYamlTableModel()
+        {
+            return new DataModelInfo
+            {
+                TypeName = "Game.Data.MonsterData",
+                PropertyName = "Monsters",
+                IsTableData = true,
+                KeyType = "int",
+                Format = "Yaml",
+                FilePath = "monsters.yaml",
+                Properties = new List<PropertyInfo>
+                {
+                    new PropertyInfo { Name = "Id", Type = "int" },
+                    new PropertyInfo { Name = "Name", Type = "string" }
+                }
+            };
+        }
+
+        private static DataModelInfo CreateYamlSingleModel()
+        {
+            return new DataModelInfo
+            {
+                TypeName = "Game.Data.GameSettings",
+                PropertyName = "Settings",
+                IsTableData = false,
+                Format = "Yaml",
+                FilePath = "settings.yaml",
+                Properties = new List<PropertyInfo>
+                {
+                    new PropertyInfo { Name = "DisplayName", Type = "string" }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a DatraEmitYamlSerializers MSBuild property for the source generator
- keep YAML serializer generation enabled by default for compatibility
- allow clients that only load bundled JSON data to avoid generated YamlDotNet references
- cover default and opt-out behavior with generator unit tests

## Tests
- dotnet test Datra.Tests/Datra.Tests.csproj -c Release --nologo --filter DataModelGeneratorTests
- dotnet test Datra.Tests/Datra.Tests.csproj -c Release --nologo
- dotnet build Datra.sln -c Release --nologo