### PR TITLE
Lazily create YAML data serializers

### DIFF
--- a/Datra.Tests/DataSerializerFactoryTests.cs
+++ b/Datra.Tests/DataSerializerFactoryTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Datra.Attributes;
+using Datra.Serializers;
+using Xunit;
+
+namespace Datra.Tests
+{
+    public class DataSerializerFactoryTests
+    {
+        [Fact]
+        public void JsonContextFactory_DoesNotCreateYamlSerializerForJsonFormat()
+        {
+            var factory = new DataSerializerFactory(TestJsonContext.Default);
+
+            var serializer = factory.GetSerializer("Units.yaml", DataFormat.Json);
+
+            Assert.IsType<SystemTextJsonDataSerializer>(serializer);
+            Assert.Null(ReadYamlSerializer(factory));
+        }
+
+        [Fact]
+        public void JsonContextFactory_CreatesYamlSerializerOnlyForYamlFormat()
+        {
+            var factory = new DataSerializerFactory(TestJsonContext.Default);
+
+            var serializer = factory.GetSerializer("Units.yaml", DataFormat.Yaml);
+
+            Assert.IsType<YamlDataSerializer>(serializer);
+            Assert.Same(serializer, ReadYamlSerializer(factory));
+        }
+
+        private static object? ReadYamlSerializer(DataSerializerFactory factory)
+        {
+            var field = typeof(DataSerializerFactory).GetField(
+                "_yamlSerializer",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return field!.GetValue(factory);
+        }
+    }
+}

--- a/Datra/Serializers/DataSerializerFactory.cs
+++ b/Datra/Serializers/DataSerializerFactory.cs
@@ -17,7 +17,8 @@ namespace Datra.Serializers
     public class DataSerializerFactory
     {
         private readonly IDataSerializer _jsonSerializer;
-        private readonly IDataSerializer _yamlSerializer;
+        private readonly Func<IDataSerializer> _createYamlSerializer;
+        private IDataSerializer? _yamlSerializer;
 
         /// <summary>
         /// Reflection-mode JSON. Trim/AOT-unsafe — explicit opt-in suitable for tooling/tests.
@@ -29,7 +30,7 @@ namespace Datra.Serializers
         public DataSerializerFactory()
         {
             _jsonSerializer = SystemTextJsonDataSerializer.CreateReflectionUnsafe();
-            _yamlSerializer = new YamlDataSerializer();
+            _createYamlSerializer = CreateDefaultYamlSerializer;
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace Datra.Serializers
         {
             if (jsonContext == null) throw new ArgumentNullException(nameof(jsonContext));
             _jsonSerializer = new SystemTextJsonDataSerializer(jsonContext);
-            _yamlSerializer = new YamlDataSerializer();
+            _createYamlSerializer = CreateDefaultYamlSerializer;
         }
 
 #if NET8_0_OR_GREATER
@@ -72,7 +73,7 @@ namespace Datra.Serializers
             IEnumerable<Type>? excludedTypes)
         {
             _jsonSerializer = SystemTextJsonDataSerializer.CreateReflectionUnsafe();
-            _yamlSerializer = new YamlDataSerializer(polymorphicBaseTypes, customYamlConverters, excludedTypes);
+            _createYamlSerializer = () => new YamlDataSerializer(polymorphicBaseTypes, customYamlConverters, excludedTypes);
         }
 
         public IDataSerializer GetSerializer(string filePath, DataFormat format = DataFormat.Auto)
@@ -85,10 +86,16 @@ namespace Datra.Serializers
             return format switch
             {
                 DataFormat.Json => _jsonSerializer,
-                DataFormat.Yaml => _yamlSerializer,
+                DataFormat.Yaml => GetYamlSerializer(),
                 DataFormat.Csv => throw new NotSupportedException("CSV format should be handled by source-generated serializers, not by DataSerializer."),
                 _ => throw new NotSupportedException($"Data format {format} is not supported.")
             };
         }
+
+        private IDataSerializer GetYamlSerializer()
+            => _yamlSerializer ?? (_yamlSerializer = _createYamlSerializer());
+
+        private static IDataSerializer CreateDefaultYamlSerializer()
+            => new YamlDataSerializer();
     }
 }


### PR DESCRIPTION
## Summary
- stop DataSerializerFactory from constructing YamlDataSerializer eagerly
- keep YAML support intact by creating it on the first YAML serializer request
- cover JSON-context factory lazy behavior with unit tests

## Why
Tidemark's browser client uses JSON-normalized DatraRawBundle data and excludes YamlDotNet from the WASM payload. Eager construction of YamlDataSerializer caused the browser runtime to load YamlDotNet even on the JSON-only path.

## Tests
- dotnet test Datra.Tests/Datra.Tests.csproj -c Release --nologo --filter "DataSerializerFactoryTests|BundleNormalizeToJsonTests|DataModelGeneratorTests"
- dotnet test Datra.Tests/Datra.Tests.csproj -c Release --nologo
- dotnet build Datra.sln -c Release --nologo